### PR TITLE
fix(ci): docker build step was incorrectly passed two args

### DIFF
--- a/.github/workflows/build-push-webhook-certificator-images.yml
+++ b/.github/workflows/build-push-webhook-certificator-images.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Build container image
         if: needs.check_if_code_changed.outputs.check_webhook_certificator == 'true'
         run: |
-          docker build  "${{ github.workspace }}" --no-cache -t local-mex-admission-webhook-certificator:${{ env.SHORT_SHA }} .
+          docker build "${{ github.workspace }}" --no-cache -t local-mex-admission-webhook-certificator:${{ env.SHORT_SHA }}
       # otherwise, fetch the :latest image from dev
       - name: Fetch latest token-injector image from dev-mex-aws-token-injector
         if: needs.check_if_code_changed.outputs.check_webhook_certificator == 'false'


### PR DESCRIPTION
- I accidentally had a second arg in the docker build step by providing both the git workspace and `.` which docker doesn't like.
- Relates: https://linear.app/prefect/issue/PLA-1167/relevant-iam-roles-sas-for-fargate-cluster-access